### PR TITLE
Changed default string limit

### DIFF
--- a/client/utils.ts
+++ b/client/utils.ts
@@ -3,7 +3,7 @@ import { Address } from "./App";
 
 export let client: TcpSocket.Socket;
 export const DEFAULT_TEXT_VALUE = " ";
-const DEFAULT_STRING_LIMIT = 20;
+const DEFAULT_STRING_LIMIT = 30;
 
 export enum MouseClicks {
 	CLICK = "c",


### PR DESCRIPTION
Changed the default string limit from 20 to 30 characters. This does not include the 2-character/byte prefixes for each message.