### PR TITLE
Dropping keyboard without the designed button breaks the state flow

### DIFF
--- a/client/components/OpenKeyboard.tsx
+++ b/client/components/OpenKeyboard.tsx
@@ -36,7 +36,12 @@ export const OpenKeyboard = () => {
 	const showKeyboard = () => setKeyboardShowing(true);
 	const hideKeyboard = () => setKeyboardShowing(false);
 
-	const handlePress = () => inputRef.current && inputRef.current.focus();
+	const handlePress = () => {
+		if (inputRef.current) {
+			inputRef.current.blur()
+			inputRef.current.focus();
+		}
+	}
 
 	return (
 		<>


### PR DESCRIPTION
If the keyboard is dropped any other way than using the designed "x" button, it will disrupt the state flow, making it impossible to bring up the keyboard again unless the app is restarted.