### PR TITLE
Do not show the close keyboard button on Android

### DIFF
--- a/client/components/OpenKeyboard.tsx
+++ b/client/components/OpenKeyboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 
 import {
 	Keyboard,
+	Platform,
 	StyleSheet,
 	View,
 	Text,
@@ -45,7 +46,7 @@ export const OpenKeyboard = () => {
 
 	return (
 		<>
-			{ keyboardShowing &&
+			{ (keyboardShowing && (Platform.OS != "android")) &&
 				<View style={styles.top}>
 					<TouchableHighlight
 						onPress={Keyboard.dismiss}


### PR DESCRIPTION
In favor of the inferior keyboard back button built into Android.