### PR TITLE
Shrink size of Touchpad to not overlap with mouse buttons

### DIFF
--- a/client/components/Touchpad.tsx
+++ b/client/components/Touchpad.tsx
@@ -63,7 +63,7 @@ export const Touchpad = () => {
 const styles = StyleSheet.create({
 	fullscreen: {
 		width: "100%",
-		height: "80%",
+		height: "75%",
 		zIndex: 1,
 	},
 });


### PR DESCRIPTION
The Touchpad covered the very top parts of the mouse buttons.